### PR TITLE
Append Main-class attribute for jar manifest.mf in order to run with -jar option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /bin
+/synthesijer.jar

--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@
     % ant jar
 
 ### Run
-    % java -jar synthesijer
+    % java -jar synthesijer.jar
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 ### Build
     % git clone https://github.com/synthesijer/synthesijer.git
     % cd synthesijer
-    % ant
     % ant jar
 
+### Run
+    % java -jar synthesijer
 

--- a/build.xml
+++ b/build.xml
@@ -40,8 +40,12 @@
             <classpath refid="synthesijer.classpath"/>
         </javac>
     </target>
-    <target name="jar" depends="init">
-	<jar basedir="./bin/" jarfile="synthesijer.jar" />
+    <target name="jar" depends="init,build">
+	<jar basedir="./bin/" jarfile="synthesijer.jar" >
+            <manifest>
+                <attribute name="Main-class" value="synthesijer.Main"/>
+            </manifest>
+        </jar>
     </target>
     <target name="jar_with_scala" depends="init">
         <jar jarfile="synthesijer_with_scala.jar">


### PR DESCRIPTION
Enable -jar option.
We can run the application with -jar option without knowing main class.
```
% java -jar synthesijer.jar
```
or
```
% java -jar synthesijer.jar -verilog Test.java Top.java
```
