### PR TITLE
sorceforge -> sourceforge

### DIFF
--- a/src/main/java/synthesijer/Main.java
+++ b/src/main/java/synthesijer/Main.java
@@ -227,7 +227,7 @@ public class Main {
 		System.out.println("  --vendor=name: to specify vendor id for generating a IP package");
 		System.out.println("  --libname=name: to specify library name for generating a IP package");
 		System.out.println();
-		System.out.println("Please access to http://synthesijer.sorceforge.net/ for more information.");
+		System.out.println("Please access to http://synthesijer.sourceforge.net/ for more information.");
 		System.out.println();
 	}
 


### PR DESCRIPTION
Fix the typo 'sorceforge'
Should be github?